### PR TITLE
feat(standards): add hcs2 support

### DIFF
--- a/__tests__/hcs-2.integration.test.ts
+++ b/__tests__/hcs-2.integration.test.ts
@@ -1,0 +1,637 @@
+/**
+ * HCS-2 Integration Tests
+ *
+ * These tests run against testnet with real transactions.
+ * No mocking - tests the actual HCS-2 implementation end-to-end.
+ */
+
+import { PrivateKey, TopicCreateTransaction } from '@hashgraph/sdk';
+import { HCS2Client } from '../src/hcs-2/client';
+import { HCS2RegistryType, HCS2Operation } from '../src/hcs-2/types';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('HCS-2 Integration Tests', () => {
+  let client: HCS2Client;
+  let operatorId: string;
+  let indexedRegistryTopicId: string;
+  let nonIndexedRegistryTopicId: string;
+  let targetTopicId: string;
+  
+  // TTL values to use in tests
+  const INDEXED_TTL = 86400; // 24 hours for indexed topics
+  const NON_INDEXED_TTL = 3600; // 1 hour for non-indexed topics
+
+  beforeAll(() => {
+    operatorId = process.env.HEDERA_ACCOUNT_ID!;
+    const operatorKey = process.env.HEDERA_PRIVATE_KEY!;
+
+    if (!operatorId || !operatorKey) {
+      throw new Error(
+        'Please set HEDERA_ACCOUNT_ID and HEDERA_PRIVATE_KEY in .env file',
+      );
+    }
+
+    client = new HCS2Client({
+      operatorId,
+      operatorKey,
+      network: 'testnet',
+    });
+  });
+
+  describe('Registry Creation', () => {
+    it('should create an indexed registry topic with correct memo format', async () => {
+      const result = await client.createRegistry({
+        registryType: HCS2RegistryType.INDEXED,
+        ttl: INDEXED_TTL,
+        memo: 'Integration test indexed registry',
+        adminKey: true,
+        submitKey: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.topicId).toBeDefined();
+      expect(result.transactionId).toBeDefined();
+
+      indexedRegistryTopicId = result.topicId!;
+      console.log(`Created indexed registry topic: ${indexedRegistryTopicId}`);
+      
+      // Verify the memo format is correct (hcs-2:0:86400)
+      const topicInfo = await (client as any).getTopicInfo(indexedRegistryTopicId);
+      expect(topicInfo.memo).toContain(`hcs-2:${HCS2RegistryType.INDEXED}:${INDEXED_TTL}`);
+    }, 30000);
+
+    it('should create a non-indexed registry topic with correct memo format', async () => {
+      const result = await client.createRegistry({
+        registryType: HCS2RegistryType.NON_INDEXED,
+        ttl: NON_INDEXED_TTL,
+        memo: 'Integration test non-indexed registry',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.topicId).toBeDefined();
+      expect(result.transactionId).toBeDefined();
+
+      nonIndexedRegistryTopicId = result.topicId!;
+      console.log(`Created non-indexed registry topic: ${nonIndexedRegistryTopicId}`);
+      
+      // Verify the memo format is correct (hcs-2:1:3600)
+      const topicInfo = await (client as any).getTopicInfo(nonIndexedRegistryTopicId);
+      expect(topicInfo.memo).toContain(`hcs-2:${HCS2RegistryType.NON_INDEXED}:${NON_INDEXED_TTL}`);
+    }, 30000);
+
+    it('should create a registry with a custom admin and submit key', async () => {
+      // 1. Generate a new key pair
+      const customKey = PrivateKey.generateED25519();
+
+      // 2. Create a registry using the custom key instance
+      const result = await client.createRegistry({
+        registryType: HCS2RegistryType.INDEXED,
+        memo: 'Integration test custom key registry',
+        adminKey: customKey,
+        submitKey: customKey,
+        
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.topicId).toBeDefined();
+      const customTopicId = result.topicId!;
+      console.log(`Created registry with custom key: ${customTopicId}`);
+
+      // 3. Wait for propagation and verify the keys on the topic
+      await new Promise(resolve => setTimeout(resolve, 8000)); // Wait for propagation
+      const topicInfo = await client.getTopicInfo(customTopicId);
+      
+      console.log('Topic info:', topicInfo);
+      expect(topicInfo.admin_key).toBeDefined();
+      expect(topicInfo.submit_key).toBeDefined();
+    }, 30000);
+
+    it('should create a target topic for testing', async () => {
+      const result = await client.createRegistry({
+        memo: 'Integration test target topic',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.topicId).toBeDefined();
+
+      targetTopicId = result.topicId!;
+      console.log(`Created target topic: ${targetTopicId}`);
+    }, 30000);
+  });
+
+  describe('Registry Operations - Indexed', () => {
+    let entryUid: number;
+    let updatedMetadataTopicId: string;
+
+    beforeAll(async () => {
+      // Create a separate topic for the "updated" metadata to make the test more robust.
+      const result = await client.createRegistry({
+        memo: 'Integration test updated metadata topic',
+      });
+      updatedMetadataTopicId = result.topicId!;
+      console.log(`Created updated metadata topic: ${updatedMetadataTopicId}`);
+    }, 30000);
+
+    it('should register an entry in the indexed registry with proper message format', async () => {
+      await new Promise(resolve => setTimeout(resolve, 5000)); // Wait longer for network propagation
+
+      const metadata = `hcs://${HCS2RegistryType.NON_INDEXED}/${targetTopicId}`;
+      const memo = 'First test entry';
+      
+      const result = await client.registerEntry(indexedRegistryTopicId, {
+        targetTopicId,
+        metadata,
+        memo,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.receipt).toBeDefined();
+
+      entryUid = result.sequenceNumber!;
+      console.log(`Registered entry with UID: ${entryUid}`);
+      
+      // Wait longer for network propagation before querying
+      await new Promise(resolve => setTimeout(resolve, 8000));
+      
+      // Verify the message structure in the registry
+      const registry = await client.getRegistry(indexedRegistryTopicId);
+      console.log('Registry after register:', JSON.stringify(registry, null, 2));
+      
+      // First try finding by sequence number
+      let entry = registry.entries.find(e => e.sequence === entryUid);
+      
+      // If not found, try finding by message content as a fallback
+      if (!entry) {
+        console.log('Entry not found by sequence, trying by content...');
+        entry = registry.entries.find(e => 
+          e.message.op === HCS2Operation.REGISTER && 
+          e.message.t_id === targetTopicId && 
+          e.message.metadata === metadata
+        );
+      }
+      
+      expect(entry).toBeDefined();
+      if (entry) {
+        expect(entry.message.p).toBe('hcs-2');
+        expect(entry.message.op).toBe(HCS2Operation.REGISTER);
+        expect(entry.message.t_id).toBe(targetTopicId);
+        expect(entry.message.metadata).toBe(metadata);
+        expect(entry.message.m).toBe(memo);
+        // Register operation shouldn't have uid
+        expect(entry.message.uid).toBeUndefined();
+      } else {
+        console.error('Failed to find registered entry in registry entries.');
+      }
+    }, 40000);
+
+    it('should update an entry in the indexed registry with proper message format', async () => {
+      await new Promise(resolve => setTimeout(resolve, 5000)); // Wait longer for network propagation
+
+      const metadata = `hcs://${HCS2RegistryType.NON_INDEXED}/${updatedMetadataTopicId}`;
+      const memo = 'Updated test entry';
+      
+      const result = await client.updateEntry(indexedRegistryTopicId, {
+        uid: entryUid.toString(),
+        targetTopicId,
+        metadata,
+        memo,
+      });
+
+      expect(result.success).toBe(true);
+      console.log(`Updated entry with UID: ${entryUid}`);
+      
+      // Wait longer for network propagation before querying
+      await new Promise(resolve => setTimeout(resolve, 8000));
+      
+      // Verify the message structure in the registry
+      const registry = await client.getRegistry(indexedRegistryTopicId);
+      console.log('Registry after update:', JSON.stringify(registry, null, 2));
+      
+      // Get the update message, first by sequence if possible, then by content
+      let entry = registry.entries.find(e => 
+        e.message.op === HCS2Operation.UPDATE && 
+        e.message.uid === entryUid.toString()
+      );
+      
+      // If not found, log for debugging
+      if (!entry) {
+        console.log('Update entry not found, checking all entries for content match...');
+        entry = registry.entries.find(e => 
+          e.message.op === HCS2Operation.UPDATE && 
+          e.message.t_id === targetTopicId && 
+          e.message.metadata === metadata
+        );
+      }
+      
+      expect(entry).toBeDefined();
+      if (entry) {
+        expect(entry.message.p).toBe('hcs-2');
+        expect(entry.message.op).toBe(HCS2Operation.UPDATE);
+        expect(entry.message.t_id).toBe(targetTopicId);
+        expect(entry.message.uid).toBe(entryUid.toString());
+        expect(entry.message.metadata).toBe(metadata);
+        expect(entry.message.m).toBe(memo);
+      } else {
+        console.error('Failed to find updated entry in registry entries.');
+      }
+    }, 40000);
+
+    it('should query the indexed registry and find the updated entry', async () => {
+      await new Promise(resolve => setTimeout(resolve, 5000)); // Wait for network propagation
+
+      const registry = await client.getRegistry(indexedRegistryTopicId);
+      expect(registry.registryType).toBe(HCS2RegistryType.INDEXED);
+      expect(registry.entries.length).toBeGreaterThan(0);
+      expect(registry.ttl).toBe(INDEXED_TTL);
+
+      // Find our updated entry
+      const updateEntry = registry.entries.find(
+        e => e.message.op === HCS2Operation.UPDATE && 
+        e.message.uid === entryUid.toString()
+      );
+      expect(updateEntry).toBeDefined();
+      expect(updateEntry!.message.metadata).toBe(
+        `hcs://${HCS2RegistryType.NON_INDEXED}/${updatedMetadataTopicId}`
+      );
+      expect(updateEntry!.message.m).toBe('Updated test entry');
+    }, 30000);
+
+    it('should delete an entry from the indexed registry with proper message format', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      const memo = 'Deleting test entry';
+      
+      const result = await client.deleteEntry(indexedRegistryTopicId, {
+        uid: entryUid.toString(),
+        memo,
+      });
+
+      expect(result.success).toBe(true);
+      console.log(`Deleted entry with UID: ${entryUid}`);
+      
+      // Wait for network propagation
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      
+      // Verify the message structure in the registry
+      const registry = await client.getRegistry(indexedRegistryTopicId);
+      const deleteEntry = registry.entries.find(
+        e => e.message.op === HCS2Operation.DELETE && 
+        e.message.uid === entryUid.toString()
+      );
+      
+      expect(deleteEntry).toBeDefined();
+      expect(deleteEntry!.message.p).toBe('hcs-2');
+      expect(deleteEntry!.message.op).toBe(HCS2Operation.DELETE);
+      expect(deleteEntry!.message.uid).toBe(entryUid.toString());
+      expect(deleteEntry!.message.m).toBe(memo);
+      // Delete operation should not have t_id
+      expect(deleteEntry!.message.t_id).toBeUndefined();
+    }, 30000);
+  });
+
+  describe('Registry Operations - Non-indexed', () => {
+    let updatedMetadataTopicId: string;
+
+    beforeAll(async () => {
+      // Create a separate topic for the "updated" metadata to make the test more robust.
+      const result = await client.createRegistry({
+        memo: 'Integration test updated metadata topic for non-indexed',
+      });
+      updatedMetadataTopicId = result.topicId!;
+      console.log(
+        `Created updated metadata topic for non-indexed: ${updatedMetadataTopicId}`,
+      );
+    }, 30000);
+
+    it('should register an entry in the non-indexed registry', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      const result = await client.registerEntry(nonIndexedRegistryTopicId, {
+        targetTopicId,
+        metadata: `hcs://${HCS2RegistryType.NON_INDEXED}/${targetTopicId}`,
+        memo: 'Non-indexed test entry',
+      });
+
+      expect(result.success).toBe(true);
+      console.log(
+        `Registered non-indexed entry with sequence: ${result.sequenceNumber}`,
+      );
+    }, 30000);
+
+    it('should register a second entry and only see that one when querying (non-indexed behavior)', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      const metadata = `hcs://${HCS2RegistryType.NON_INDEXED}/${updatedMetadataTopicId}`;
+      const memo = 'Latest non-indexed entry';
+      
+      const result = await client.registerEntry(nonIndexedRegistryTopicId, {
+        targetTopicId,
+        metadata,
+        memo,
+      });
+
+      expect(result.success).toBe(true);
+
+      // Wait for network propagation
+      await new Promise(resolve => setTimeout(resolve, 5000));
+
+      // Query the registry - should only show the latest entry for non-indexed registry
+      const registry = await client.getRegistry(nonIndexedRegistryTopicId);
+      
+      expect(registry.registryType).toBe(HCS2RegistryType.NON_INDEXED);
+      expect(registry.ttl).toBe(NON_INDEXED_TTL);
+      expect(registry.entries.length).toBe(1); // Only latest message is returned
+      expect(registry.entries[0].message.metadata).toBe(metadata);
+      expect(registry.entries[0].message.m).toBe(memo);
+    }, 30000);
+
+    it('should verify that update operations are not allowed on non-indexed registries', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      // Try to update an entry in a non-indexed registry - should fail
+      await expect(
+        client.updateEntry(nonIndexedRegistryTopicId, {
+          uid: '1', // Any UID
+          targetTopicId,
+          metadata: `hcs://${HCS2RegistryType.NON_INDEXED}/${targetTopicId}`,
+        })
+      ).rejects.toThrow(/only valid for indexed registries/);
+    }, 30000);
+
+    it('should verify that delete operations are not allowed on non-indexed registries', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      // Try to delete an entry in a non-indexed registry - should fail
+      await expect(
+        client.deleteEntry(nonIndexedRegistryTopicId, {
+          uid: '1', // Any UID
+        })
+      ).rejects.toThrow(/only valid for indexed registries/);
+    }, 30000);
+  });
+
+  describe('Registry Migration', () => {
+    let newTopicId: string;
+
+    it('should create a new topic for migration', async () => {
+      const result = await client.createRegistry({
+        registryType: HCS2RegistryType.INDEXED,
+        ttl: INDEXED_TTL,
+        memo: 'Migration target topic',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.topicId).toBeDefined();
+
+      newTopicId = result.topicId!;
+      console.log(`Created migration target topic: ${newTopicId}`);
+    }, 30000);
+
+    it('should migrate a registry to a new topic with proper message format', async () => {
+      await new Promise(resolve => setTimeout(resolve, 3000)); // Wait for network propagation
+
+      const metadata = `hcs://${HCS2RegistryType.NON_INDEXED}/${targetTopicId}`;
+      const memo = 'Migrating to new topic';
+      
+      const result = await client.migrateRegistry(indexedRegistryTopicId, {
+        targetTopicId: newTopicId,
+        metadata,
+        memo,
+      });
+
+      expect(result.success).toBe(true);
+      console.log(`Migrated registry to new topic: ${newTopicId}`);
+      
+      // Wait for network propagation
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      
+      // Verify the message structure in the registry
+      const registry = await client.getRegistry(indexedRegistryTopicId);
+      const migrateOp = registry.entries.find(
+        e => e.message.op === HCS2Operation.MIGRATE && e.message.t_id === newTopicId
+      );
+      
+      expect(migrateOp).toBeDefined();
+      expect(migrateOp!.message.p).toBe('hcs-2');
+      expect(migrateOp!.message.op).toBe(HCS2Operation.MIGRATE);
+      expect(migrateOp!.message.t_id).toBe(newTopicId);
+      expect(migrateOp!.message.metadata).toBe(metadata);
+      expect(migrateOp!.message.m).toBe(memo);
+      // Migrate operation shouldn't have uid
+      expect(migrateOp!.message.uid).toBeUndefined();
+    }, 30000);
+  });
+
+  describe('Message Validation', () => {
+    it('should validate well-formed messages', async () => {
+      // Valid register message
+      const registerMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345',
+        metadata: `hcs://1/0.0.12345`,
+        m: 'Test memo',
+      };
+      const validRegisterResult = (client as any).validateMessage(registerMessage);
+      expect(validRegisterResult.valid).toBe(true);
+      
+      // Valid update message
+      const updateMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.UPDATE,
+        uid: '123',
+        t_id: '0.0.12345',
+        metadata: `hcs://1/0.0.12345`,
+      };
+      const validUpdateResult = (client as any).validateMessage(updateMessage);
+      expect(validUpdateResult.valid).toBe(true);
+      
+      // Valid delete message
+      const deleteMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.DELETE,
+        uid: '123',
+      };
+      const validDeleteResult = (client as any).validateMessage(deleteMessage);
+      expect(validDeleteResult.valid).toBe(true);
+      
+      // Valid migrate message
+      const migrateMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.MIGRATE,
+        t_id: '0.0.12345',
+      };
+      const validMigrateResult = (client as any).validateMessage(migrateMessage);
+      expect(validMigrateResult.valid).toBe(true);
+    });
+
+    it('should reject malformed messages', async () => {
+      // Wrong protocol
+      const wrongProtocol = {
+        p: 'wrong-protocol',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345',
+      };
+      const wrongProtocolResult = (client as any).validateMessage(wrongProtocol);
+      expect(wrongProtocolResult.valid).toBe(false);
+      expect(wrongProtocolResult.errors).toContain('p: Invalid literal value, expected "hcs-2"');
+      
+      // Missing t_id in register
+      const missingTargetId = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+      };
+      const missingTargetIdResult = (client as any).validateMessage(missingTargetId);
+      expect(missingTargetIdResult.valid).toBe(false);
+      expect(missingTargetIdResult.errors).toContain(`t_id: Required`);
+      
+      // Missing uid in update
+      const missingUid = {
+        p: 'hcs-2',
+        op: HCS2Operation.UPDATE,
+        t_id: '0.0.12345',
+      };
+      const missingUidResult = (client as any).validateMessage(missingUid);
+      expect(missingUidResult.valid).toBe(false);
+      expect(missingUidResult.errors).toContain('uid: Required');
+      
+      // Memo too long (over 500 chars)
+      const longMemo = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345',
+        m: 'a'.repeat(501),
+      };
+      const longMemoResult = (client as any).validateMessage(longMemo);
+      expect(longMemoResult.valid).toBe(false);
+      expect(longMemoResult.errors).toContain('m: Memo must not exceed 500 characters');
+    });
+
+    it('should handle attempts to get registry info from non-HCS-2 topics', async () => {
+      // Create a regular topic without HCS-2 memo using a direct transaction
+      const hederaClient = (client as any).client;
+
+      const receipt = await new TopicCreateTransaction()
+        .setTopicMemo('Regular topic without HCS-2 format')
+        .execute(hederaClient)
+        .then(resp => resp.getReceipt(hederaClient));
+
+      const regularTopicId = receipt.topicId!.toString();
+
+      // Wait for network propagation
+      await new Promise(resolve => setTimeout(resolve, 3000));
+
+      // Try to treat it as an HCS-2 registry - should fail
+      await expect(client.getRegistry(regularTopicId)).rejects.toThrow(
+        /not an HCS-2 registry/
+      );
+    }, 30000);
+  });
+
+  describe('Pagination', () => {
+    let paginationTestTopicId: string;
+    const totalEntries = 5;
+
+    beforeAll(async () => {
+      // Ensure targetTopicId exists
+      if (!targetTopicId) {
+        const result = await client.createRegistry({
+          memo: 'Pagination test target topic',
+        });
+        targetTopicId = result.topicId!;
+        console.log(`Created target topic for pagination: ${targetTopicId}`);
+      }
+
+      // Create a dedicated topic for pagination tests
+      const result = await client.createRegistry({
+        registryType: HCS2RegistryType.INDEXED,
+        memo: 'Pagination test registry',
+      });
+      paginationTestTopicId = result.topicId!;
+      console.log(`Created pagination test topic: ${paginationTestTopicId}`);
+
+      // Add 5 entries to it
+      for (let i = 1; i <= totalEntries; i++) {
+        await client.registerEntry(paginationTestTopicId, {
+          targetTopicId: targetTopicId, // Use the globally created target topic
+          metadata: `Entry ${i}`,
+          memo: `Pagination test entry ${i}`,
+        });
+        // Short delay between transactions to avoid duplicates
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+
+      // Wait for all messages to propagate
+      await new Promise(resolve => setTimeout(resolve, 10000));
+    }, 60000);
+
+    it('should skip the first 2 entries and limit to 2', async () => {
+      const registry = await client.getRegistry(paginationTestTopicId, {
+        skip: 2,
+        limit: 2,
+        order: 'asc',
+      });
+
+      expect(registry.entries.length).toBe(2);
+      // Since we skipped 2, we should get sequence numbers 3 and 4
+      expect(registry.entries[0].sequence).toBe(3);
+      expect(registry.entries[1].sequence).toBe(4);
+    }, 30000);
+
+    it('should get the last page of results', async () => {
+      const registry = await client.getRegistry(paginationTestTopicId, {
+        skip: 4,
+        limit: 2,
+        order: 'asc',
+      });
+
+      expect(registry.entries.length).toBe(1);
+      // Since we skipped 4, we should get the last entry with sequence number 5
+      expect(registry.entries[0].sequence).toBe(5);
+    }, 30000);
+
+    it('should return 0 entries if skip is greater than total entries', async () => {
+      const registry = await client.getRegistry(paginationTestTopicId, {
+        skip: totalEntries,
+        limit: 2,
+        order: 'asc',
+      });
+
+      expect(registry.entries.length).toBe(0);
+    }, 30000);
+  });
+
+  describe('Key Type Detection', () => {
+    it('should detect ED25519 key type and retain the correct operator key', () => {
+      const privateKey = PrivateKey.generateED25519();
+      const keyString = privateKey.toString();
+      const client = new HCS2Client({ operatorId, operatorKey: keyString, network: 'testnet' });
+      expect(client.getKeyType()).toBe('ed25519');
+      expect(client.getOperatorKey().toString()).toBe(keyString);
+    });
+
+    it('should detect ECDSA key type when explicitly set', () => {
+      const privateKey = PrivateKey.generateECDSA();
+      const raw = privateKey.toStringRaw();
+      // Using raw hex for ECDSA
+      const client = new HCS2Client({ operatorId, operatorKey: raw, network: 'testnet', keyType: 'ecdsa' });
+      expect(client.getKeyType()).toBe('ecdsa');
+      expect(client.getOperatorKey().toStringRaw()).toBe(raw);
+    });
+
+    it('should auto-detect ECDSA key with 0x prefix', () => {
+      const privateKey = PrivateKey.generateECDSA();
+      const raw = privateKey.toStringRaw();
+      const keyString = '0x' + raw;
+      const client = new HCS2Client({ operatorId, operatorKey: keyString, network: 'testnet' });
+      expect(client.getKeyType()).toBe('ecdsa');
+      expect(client.getOperatorKey().toStringRaw()).toBe(raw);
+    });
+  });
+
+  afterAll(async () => {
+     client.close();
+  });
+}); 

--- a/__tests__/hcs-2.schema.test.ts
+++ b/__tests__/hcs-2.schema.test.ts
@@ -1,0 +1,219 @@
+/**
+ * HCS-2 Schema Validation Tests
+ * 
+ * Tests the Zod schema validation for HCS-2 messages
+ */
+
+import {
+  hcs2MessageSchema,
+  registerMessageSchema,
+  updateMessageSchema,
+  deleteMessageSchema,
+  migrateMessageSchema,
+  HCS2Operation
+} from '../src/hcs-2/types';
+
+describe('HCS-2 Zod Schema Validation', () => {
+  describe('Register Message Schema', () => {
+    it('should validate a valid register message', () => {
+      const validMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345',
+        metadata: 'hcs://1/0.0.12345',
+        m: 'Test memo'
+      };
+      
+      const result = registerMessageSchema.safeParse(validMessage);
+      expect(result.success).toBe(true);
+    });
+    
+    it('should reject a register message without t_id', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        metadata: 'hcs://1/0.0.12345'
+      };
+      
+      const result = registerMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('t_id');
+      }
+    });
+    
+    it('should reject a register message with invalid topic ID format', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: 'invalid-format',
+        metadata: 'hcs://1/0.0.12345'
+      };
+      
+      const result = registerMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('t_id');
+      }
+    });
+    
+    it('should reject a register message with memo exceeding 500 characters', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345',
+        m: 'a'.repeat(501)
+      };
+      
+      const result = registerMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('m');
+      }
+    });
+  });
+  
+  describe('Update Message Schema', () => {
+    it('should validate a valid update message', () => {
+      const validMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.UPDATE,
+        uid: '123',
+        t_id: '0.0.12345',
+        metadata: 'hcs://1/0.0.12345'
+      };
+      
+      const result = updateMessageSchema.safeParse(validMessage);
+      expect(result.success).toBe(true);
+    });
+    
+    it('should reject an update message without uid', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.UPDATE,
+        t_id: '0.0.12345'
+      };
+      
+      const result = updateMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('uid');
+      }
+    });
+  });
+  
+  describe('Delete Message Schema', () => {
+    it('should validate a valid delete message', () => {
+      const validMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.DELETE,
+        uid: '123'
+      };
+      
+      const result = deleteMessageSchema.safeParse(validMessage);
+      expect(result.success).toBe(true);
+    });
+    
+    it('should reject a delete message without uid', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.DELETE
+      };
+      
+      const result = deleteMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('uid');
+      }
+    });
+  });
+  
+  describe('Migrate Message Schema', () => {
+    it('should validate a valid migrate message', () => {
+      const validMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.MIGRATE,
+        t_id: '0.0.12345',
+        metadata: 'hcs://1/0.0.12345'
+      };
+      
+      const result = migrateMessageSchema.safeParse(validMessage);
+      expect(result.success).toBe(true);
+    });
+    
+    it('should reject a migrate message without t_id', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.MIGRATE
+      };
+      
+      const result = migrateMessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('t_id');
+      }
+    });
+  });
+  
+  describe('Combined Schema', () => {
+    it('should validate messages based on operation type', () => {
+      const registerMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345'
+      };
+      
+      const updateMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.UPDATE,
+        uid: '123',
+        t_id: '0.0.12345'
+      };
+      
+      const deleteMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.DELETE,
+        uid: '123'
+      };
+      
+      const migrateMessage = {
+        p: 'hcs-2',
+        op: HCS2Operation.MIGRATE,
+        t_id: '0.0.12345'
+      };
+      
+      expect(hcs2MessageSchema.safeParse(registerMessage).success).toBe(true);
+      expect(hcs2MessageSchema.safeParse(updateMessage).success).toBe(true);
+      expect(hcs2MessageSchema.safeParse(deleteMessage).success).toBe(true);
+      expect(hcs2MessageSchema.safeParse(migrateMessage).success).toBe(true);
+    });
+    
+    it('should reject messages with invalid protocol', () => {
+      const invalidMessage = {
+        p: 'wrong-protocol',
+        op: HCS2Operation.REGISTER,
+        t_id: '0.0.12345'
+      };
+      
+      const result = hcs2MessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('p');
+      }
+    });
+    
+    it('should reject messages with invalid operation type', () => {
+      const invalidMessage = {
+        p: 'hcs-2',
+        op: 'invalid-op' as HCS2Operation,
+        t_id: '0.0.12345'
+      };
+      
+      const result = hcs2MessageSchema.safeParse(invalidMessage);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors[0].path).toContain('op');
+      }
+    });
+  });
+}); 

--- a/src/hcs-2/base-client.ts
+++ b/src/hcs-2/base-client.ts
@@ -1,0 +1,314 @@
+import { Logger } from '../utils/logger';
+import { HederaMirrorNode } from '../services/mirror-node';
+import { 
+  HCS2ClientConfig, 
+  HCS2Message, 
+  HCS2Operation, 
+  HCS2RegisterMessage,
+  HCS2UpdateMessage,
+  HCS2DeleteMessage,
+  HCS2MigrateMessage,
+  HCS2RegistryType,
+  TopicRegistrationResponse,
+  RegistryOperationResponse,
+  RegistryEntry,
+  TopicRegistry,
+  CreateRegistryOptions,
+  RegisterEntryOptions,
+  UpdateEntryOptions,
+  DeleteEntryOptions,
+  MigrateTopicOptions,
+  QueryRegistryOptions,
+  hcs2MessageSchema
+} from './types';
+import { TransactionReceipt } from '@hashgraph/sdk';
+import { NetworkType } from '../utils/types';
+import { ZodError } from 'zod';
+
+/**
+ * Base client for HCS-2 operations
+ * This abstract class provides shared functionality for both SDK and browser implementations
+ */
+export abstract class HCS2BaseClient {
+  protected logger: Logger;
+  protected mirrorNode: HederaMirrorNode;
+  protected network: NetworkType;
+
+  /**
+   * Create a new HCS-2 base client
+   * @param config Client configuration
+   */
+  constructor(config: HCS2ClientConfig) {
+    this.network = config.network;
+    
+    this.logger = Logger.getInstance({
+      level: config.logLevel || 'info',
+      module: 'HCS2Client',
+      silent: config.silent,
+    });
+    
+    this.mirrorNode = new HederaMirrorNode(
+      this.network,
+      this.logger,
+      config.mirrorNodeUrl ? { customUrl: config.mirrorNodeUrl } : undefined
+    );
+  }
+
+  /**
+   * Create a new registry topic
+   * @param options Registry creation options
+   * @returns Promise resolving to the transaction result
+   */
+  abstract createRegistry(options: CreateRegistryOptions): Promise<TopicRegistrationResponse>;
+
+  /**
+   * Register a new entry in the registry
+   * @param registryTopicId The topic ID of the registry
+   * @param options Registration options
+   * @returns Promise resolving to the operation result
+   */
+  abstract registerEntry(registryTopicId: string, options: RegisterEntryOptions): Promise<RegistryOperationResponse>;
+
+  /**
+   * Update an existing entry in the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Update options
+   * @returns Promise resolving to the operation result
+   */
+  abstract updateEntry(registryTopicId: string, options: UpdateEntryOptions): Promise<RegistryOperationResponse>;
+
+  /**
+   * Delete an entry from the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Delete options
+   * @returns Promise resolving to the operation result
+   */
+  abstract deleteEntry(registryTopicId: string, options: DeleteEntryOptions): Promise<RegistryOperationResponse>;
+
+  /**
+   * Migrate a registry to a new topic
+   * @param registryTopicId The topic ID of the registry
+   * @param options Migration options
+   * @returns Promise resolving to the operation result
+   */
+  abstract migrateRegistry(registryTopicId: string, options: MigrateTopicOptions): Promise<RegistryOperationResponse>;
+
+  /**
+   * Get all entries from a registry
+   * @param topicId The topic ID of the registry
+   * @param options Query options
+   * @returns Promise resolving to the registry information
+   */
+  abstract getRegistry(topicId: string, options?: QueryRegistryOptions): Promise<TopicRegistry>;
+  
+  /**
+   * Submit a message to a topic
+   * @param topicId The topic ID to submit to
+   * @param payload The message payload
+   * @returns Promise resolving to the transaction receipt
+   */
+  abstract submitMessage(topicId: string, payload: HCS2Message): Promise<TransactionReceipt>;
+
+  /**
+   * Determine the registry type from a topic memo
+   * @param memo The topic memo
+   * @returns The registry type or undefined if not found
+   */
+  protected parseRegistryTypeFromMemo(memo: string): { registryType: HCS2RegistryType; ttl: number } | undefined {
+    try {
+      const regex = /hcs-2:(\d):(\d+)/;
+      const match = memo.match(regex);
+      
+      if (match && match.length === 3) {
+        const registryType = parseInt(match[1]) as HCS2RegistryType;
+        const ttl = parseInt(match[2]);
+        
+        if (registryType !== undefined && !isNaN(ttl)) {
+          return { registryType, ttl };
+        }
+      }
+      
+      return undefined;
+    } catch (error) {
+      this.logger.error(`Error parsing registry type from memo: ${error}`);
+      return undefined;
+    }
+  }
+
+  /**
+   * Generate a memo string for a registry topic
+   * @param registryType The registry type
+   * @param ttl The time-to-live in seconds
+   * @returns The memo string
+   */
+  protected generateRegistryMemo(registryType: HCS2RegistryType, ttl: number): string {
+    return `hcs-2:${registryType}:${ttl}`;
+  }
+
+  /**
+   * Validate a HCS-2 message
+   * @param message The message to validate
+   * @returns Validation result
+   */
+  protected validateMessage(message: any): { valid: boolean; errors: string[] } {
+    try {
+      // Use Zod schema for validation
+      hcs2MessageSchema.parse(message);
+      return { valid: true, errors: [] };
+    } catch (error) {
+      const errors: string[] = [];
+      
+      if (error instanceof ZodError) {
+        // Format Zod errors for better readability
+        error.errors.forEach(err => {
+          const path = err.path.join('.');
+          errors.push(`${path ? path + ': ' : ''}${err.message}`);
+        });
+      } else {
+        // Handle non-Zod errors
+        errors.push(`Unexpected error: ${error}`);
+      }
+      
+      this.logger.debug(`Message validation failed: ${errors.join(', ')}`);
+      return { valid: false, errors };
+    }
+  }
+
+  /**
+   * Create a register message
+   * @param targetTopicId The target topic ID
+   * @param metadata Optional metadata URI
+   * @param memo Optional memo
+   * @returns The register message
+   */
+  protected createRegisterMessage(targetTopicId: string, metadata?: string, memo?: string): HCS2RegisterMessage {
+    return {
+      p: 'hcs-2',
+      op: HCS2Operation.REGISTER,
+      t_id: targetTopicId,
+      metadata,
+      m: memo
+    };
+  }
+
+  /**
+   * Create an update message
+   * @param targetTopicId The target topic ID
+   * @param uid The unique ID to update
+   * @param metadata Optional metadata URI
+   * @param memo Optional memo
+   * @returns The update message
+   */
+  protected createUpdateMessage(targetTopicId: string, uid: string, metadata?: string, memo?: string): HCS2UpdateMessage {
+    return {
+      p: 'hcs-2',
+      op: HCS2Operation.UPDATE,
+      t_id: targetTopicId,
+      uid,
+      metadata,
+      m: memo
+    };
+  }
+
+  /**
+   * Create a delete message
+   * @param uid The unique ID to delete
+   * @param memo Optional memo
+   * @returns The delete message
+   */
+  protected createDeleteMessage(uid: string, memo?: string): HCS2DeleteMessage {
+    return {
+      p: 'hcs-2',
+      op: HCS2Operation.DELETE,
+      uid,
+      m: memo
+    };
+  }
+
+  /**
+   * Create a migrate message
+   * @param targetTopicId The target topic ID to migrate to
+   * @param metadata Optional metadata URI
+   * @param memo Optional memo
+   * @returns The migrate message
+   */
+  protected createMigrateMessage(targetTopicId: string, metadata?: string, memo?: string): HCS2MigrateMessage {
+    return {
+      p: 'hcs-2',
+      op: HCS2Operation.MIGRATE,
+      t_id: targetTopicId,
+      metadata,
+      m: memo
+    };
+  }
+
+  /**
+   * Parse registry entries from topic messages
+   * @param topicId The topic ID
+   * @param messages The messages to parse
+   * @param registryType The registry type
+   * @param ttl The time-to-live in seconds
+   * @returns The parsed registry
+   */
+  protected parseRegistryEntries(
+    topicId: string,
+    messages: any[],
+    registryType: HCS2RegistryType,
+    ttl: number
+  ): TopicRegistry {
+    const entries: RegistryEntry[] = [];
+    let latestEntry: RegistryEntry | undefined;
+
+    this.logger.debug(`Parsing ${messages.length} messages for topic ${topicId}`);
+    
+    for (const msg of messages) {
+      try {
+        if (!msg.message) {
+          this.logger.debug(`Message is missing 'message' property: ${JSON.stringify(msg)}`);
+          continue;
+        }
+        
+        const decodedMessage = Buffer.from(msg.message, 'base64').toString('utf-8');
+        const message = JSON.parse(decodedMessage);
+        
+        this.logger.debug(`Successfully parsed message: ${JSON.stringify(message)}`);
+        
+        // Validate message
+        const { valid, errors } = this.validateMessage(message);
+        if (!valid) {
+          this.logger.warn(`Invalid HCS-2 message: ${errors.join(', ')}`);
+          continue;
+        }
+        
+        const entry: RegistryEntry = {
+          topicId,
+          sequence: msg.sequence_number,
+          timestamp: msg.consensus_timestamp,
+          payer: msg.payer_account_id,
+          message,
+          consensus_timestamp: msg.consensus_timestamp,
+          registry_type: registryType
+        };
+        
+        entries.push(entry);
+        
+        // For non-indexed registries, we only care about the latest message
+        if (registryType === HCS2RegistryType.NON_INDEXED || !latestEntry || entry.timestamp > latestEntry.timestamp) {
+          latestEntry = entry;
+        }
+      } catch (error) {
+        this.logger.warn(`Error parsing message: ${error}`);
+      }
+    }
+
+    this.logger.debug(`Parsed ${entries.length} valid entries for topic ${topicId}`);
+    
+    return {
+      topicId,
+      registryType,
+      ttl,
+      entries: registryType === HCS2RegistryType.INDEXED ? entries : (latestEntry ? [latestEntry] : []),
+      latestEntry
+    };
+  }
+} 

--- a/src/hcs-2/browser.ts
+++ b/src/hcs-2/browser.ts
@@ -1,0 +1,376 @@
+import { 
+  TransactionReceipt, 
+  TopicCreateTransaction,
+  TopicMessageSubmitTransaction,
+  TopicId,
+  PublicKey,
+} from '@hashgraph/sdk';
+import { HashinalsWalletConnectSDK } from '@hashgraphonline/hashinal-wc';
+import { HCS2BaseClient } from './base-client';
+import {
+  HCS2ClientConfig,
+  HCS2Message,
+  HCS2Operation,
+  HCS2RegistryType,
+  TopicRegistrationResponse,
+  RegistryOperationResponse,
+  TopicRegistry,
+  CreateRegistryOptions,
+  RegisterEntryOptions,
+  UpdateEntryOptions,
+  DeleteEntryOptions,
+  MigrateTopicOptions,
+  QueryRegistryOptions
+} from './types';
+import { isBrowser } from '../utils/is-browser';
+
+/**
+ * Browser client configuration for HCS-2
+ */
+export interface BrowserHCS2Config extends HCS2ClientConfig {
+  hwc: HashinalsWalletConnectSDK;
+}
+
+/**
+ * Browser client for HCS-2 operations
+ */
+export class BrowserHCS2Client extends HCS2BaseClient {
+  private hwc: HashinalsWalletConnectSDK;
+
+  /**
+   * Create a new browser HCS-2 client
+   * @param config Client configuration
+   */
+  constructor(config: BrowserHCS2Config) {
+    super({
+      network: config.network,
+      logLevel: config.logLevel,
+      silent: config.silent,
+      mirrorNodeUrl: config.mirrorNodeUrl,
+    });
+
+    this.hwc = config.hwc;
+    
+    if (!isBrowser) {
+      this.logger.error(
+        'BrowserHCS2Client initialized in server environment - browser-specific features will not be available. Use HCS2Client instead.',
+      );
+    } else {
+      this.logger.info('HCS-2 browser client initialized successfully');
+    }
+  }
+
+  /**
+   * Get the operator account ID
+   * @returns The operator account ID
+   */
+  private getOperatorId(): string {
+    const accountInfo = this.hwc.getAccountInfo();
+    if (!accountInfo || !accountInfo.accountId) {
+      throw new Error('No connected account found');
+    }
+    return accountInfo.accountId;
+  }
+
+  /**
+   * Create a new registry topic
+   * @param options Registry creation options
+   * @returns Promise resolving to the transaction result
+   */
+  async createRegistry(options: CreateRegistryOptions = {}): Promise<TopicRegistrationResponse> {
+    try {
+      const registryType = options.registryType ?? HCS2RegistryType.INDEXED;
+      const ttl = options.ttl ?? 86400; // Default TTL: 24 hours
+      
+      const memo = options.memo 
+        ? `${this.generateRegistryMemo(registryType, ttl)} ${options.memo}`.trim() 
+        : this.generateRegistryMemo(registryType, ttl);
+      
+      let transaction = new TopicCreateTransaction()
+        .setTopicMemo(memo);
+      
+      // Add admin key if requested (using connected wallet)
+      if (options.adminKey) {
+        let adminPublicKey: PublicKey;
+        if (typeof options.adminKey === 'string') {
+          adminPublicKey = PublicKey.fromString(options.adminKey);
+        } else if (typeof options.adminKey === 'boolean') {
+          adminPublicKey = await this.mirrorNode.getPublicKey(this.getOperatorId());
+        } else {
+          // Provided as PrivateKey instance
+          adminPublicKey = options.adminKey.publicKey;
+        }
+        transaction = transaction.setAdminKey(adminPublicKey);
+      }
+      
+      // Add submit key if requested (using connected wallet)
+      if (options.submitKey) {
+        let submitPublicKey: PublicKey;
+        if (typeof options.submitKey === 'string') {
+          submitPublicKey = PublicKey.fromString(options.submitKey);
+        } else if (typeof options.submitKey === 'boolean') {
+          submitPublicKey = await this.mirrorNode.getPublicKey(this.getOperatorId());
+        } else {
+          submitPublicKey = options.submitKey.publicKey;
+        }
+        transaction = transaction.setSubmitKey(submitPublicKey);
+      }
+      
+      const txResponse = await (this.hwc as any).executeTransactionWithErrorHandling(
+        transaction,
+        false,
+      );
+      
+      if (txResponse?.error) {
+        throw new Error(txResponse.error);
+      }
+      
+      const resultReceipt = txResponse?.result;
+      if (!resultReceipt?.topicId) {
+        throw new Error('Failed to create registry: No topic ID in receipt');
+      }
+      
+      const topicId = resultReceipt.topicId.toString();
+      
+      this.logger.info(`Created registry topic: ${topicId} (${registryType === HCS2RegistryType.INDEXED ? 'Indexed' : 'Non-indexed'}, TTL: ${ttl}s)`);
+      
+      return {
+        success: true,
+        topicId,
+        transactionId: txResponse.transactionId || 'unknown'
+      };
+    } catch (error) {
+      this.logger.error(`Failed to create registry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to create registry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Register a new entry in the registry
+   * @param registryTopicId The topic ID of the registry
+   * @param options Registration options
+   * @returns Promise resolving to the operation result
+   */
+  async registerEntry(registryTopicId: string, options: RegisterEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Create register message
+      const message = this.createRegisterMessage(
+        options.targetTopicId,
+        options.metadata,
+        options.memo
+      );
+      
+      // Ensure operation type is correctly set
+      if (message.op !== HCS2Operation.REGISTER) {
+        throw new Error(`Invalid operation type: ${message.op}, expected ${HCS2Operation.REGISTER}`);
+      }
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Registered entry in registry ${registryTopicId} pointing to topic ${options.targetTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to register entry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to register entry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Update an existing entry in the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Update options
+   * @returns Promise resolving to the operation result
+   */
+  async updateEntry(registryTopicId: string, options: UpdateEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Verify registry type (only indexed registries support updates)
+      const registryInfo = await this.mirrorNode.getTopicInfo(registryTopicId);
+      const memoInfo = this.parseRegistryTypeFromMemo(registryInfo.memo);
+      
+      if (!memoInfo || memoInfo.registryType !== HCS2RegistryType.INDEXED) {
+        throw new Error('Update operation is only valid for indexed registries');
+      }
+      
+      const message = this.createUpdateMessage(
+        options.targetTopicId,
+        options.uid,
+        options.metadata,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Updated entry with UID ${options.uid} in registry ${registryTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to update entry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to update entry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Delete an entry from the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Delete options
+   * @returns Promise resolving to the operation result
+   */
+  async deleteEntry(registryTopicId: string, options: DeleteEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Verify registry type (only indexed registries support deletions)
+      const registryInfo = await this.mirrorNode.getTopicInfo(registryTopicId);
+      const memoInfo = this.parseRegistryTypeFromMemo(registryInfo.memo);
+      
+      if (!memoInfo || memoInfo.registryType !== HCS2RegistryType.INDEXED) {
+        throw new Error('Delete operation is only valid for indexed registries');
+      }
+      
+      // Create delete message
+      const message = this.createDeleteMessage(
+        options.uid,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Deleted entry with UID ${options.uid} from registry ${registryTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to delete entry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to delete entry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Migrate a registry to a new topic
+   * @param registryTopicId The topic ID of the registry
+   * @param options Migration options
+   * @returns Promise resolving to the operation result
+   */
+  async migrateRegistry(registryTopicId: string, options: MigrateTopicOptions): Promise<RegistryOperationResponse> {
+    try {
+      const message = this.createMigrateMessage(
+        options.targetTopicId,
+        options.metadata,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Migrated registry ${registryTopicId} to ${options.targetTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to migrate registry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to migrate registry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Get all entries from a registry
+   * @param topicId The topic ID of the registry
+   * @param options Query options
+   * @returns Promise resolving to the registry information
+   */
+  async getRegistry(topicId: string, options: QueryRegistryOptions = {}): Promise<TopicRegistry> {
+    try {
+      // Get topic info to determine registry type
+      const topicInfo = await this.mirrorNode.getTopicInfo(topicId);
+      const memoInfo = this.parseRegistryTypeFromMemo(topicInfo.memo);
+      
+      if (!memoInfo) {
+        throw new Error(`Topic ${topicId} is not an HCS-2 registry (invalid memo format)`);
+      }
+      
+      const messagesResult = await this.mirrorNode.getTopicMessages(
+        topicId,
+        {
+          sequenceNumber: options.skip && options.skip > 0 ? `gt:${options.skip}` : undefined,
+          limit: options.limit ?? 100,
+          order: options.order ?? 'asc'
+        }
+      );
+      
+      // Since getTopicMessages fetches all pages, we must manually truncate if a limit was set.
+      const messages = options.limit ? messagesResult.slice(0, options.limit) : messagesResult;
+      
+      // Parse messages into registry entries
+      return this.parseRegistryEntries(
+        topicId,
+        messages,
+        memoInfo.registryType,
+        memoInfo.ttl
+      );
+    } catch (error) {
+      this.logger.error(`Failed to get registry: ${error}`);
+      throw error;
+    }
+  }
+  
+  /**
+   * Submit a message to a topic
+   * @param topicId The topic ID to submit to
+   * @param payload The message payload
+   * @returns Promise resolving to the transaction receipt
+   */
+  async submitMessage(topicId: string, payload: HCS2Message): Promise<TransactionReceipt> {
+    try {
+      // Validate message
+      const { valid, errors } = this.validateMessage(payload);
+      if (!valid) {
+        throw new Error(`Invalid HCS-2 message: ${errors.join(', ')}`);
+      }
+      
+      const transaction = new TopicMessageSubmitTransaction()
+        .setTopicId(TopicId.fromString(topicId))
+        .setMessage(JSON.stringify(payload));
+      
+      const txResponse = await (this.hwc as any).executeTransactionWithErrorHandling(
+        transaction,
+        false,
+      );
+      
+      if (txResponse?.error) {
+        throw new Error(txResponse.error);
+      }
+      
+      return txResponse.result;
+    } catch (error) {
+      this.logger.error(`Failed to submit message: ${error}`);
+      throw error;
+    }
+  }
+} 

--- a/src/hcs-2/client.ts
+++ b/src/hcs-2/client.ts
@@ -1,0 +1,499 @@
+import {
+  Client,
+  TopicCreateTransaction,
+  TopicMessageSubmitTransaction,
+  PrivateKey,
+  TopicId,
+  TransactionReceipt,
+  AccountId,
+  PublicKey,
+} from '@hashgraph/sdk';
+import { HCS2BaseClient } from './base-client';
+import {
+  HCS2ClientConfig,
+  HCS2Message,
+  HCS2RegistryType,
+  TopicRegistrationResponse,
+  RegistryOperationResponse,
+  TopicRegistry,
+  CreateRegistryOptions,
+  RegisterEntryOptions,
+  UpdateEntryOptions,
+  DeleteEntryOptions,
+  MigrateTopicOptions,
+  QueryRegistryOptions,
+  RegistryEntry
+} from './types';
+import { NetworkType } from '../utils/types';
+import { detectKeyTypeFromString } from '../utils/key-type-detector';
+
+/**
+ * SDK client configuration for HCS-2
+ */
+export interface SDKHCS2ClientConfig extends HCS2ClientConfig {
+  operatorId: string | AccountId;
+  operatorKey: string | PrivateKey;
+  keyType?: 'ed25519' | 'ecdsa';
+}
+
+/**
+ * SDK client for HCS-2 operations
+ */
+export class HCS2Client extends HCS2BaseClient {
+  private client: Client;
+  private operatorId: AccountId;
+  private operatorKey: PrivateKey;
+  private initialized = false;
+  private keyType: 'ed25519' | 'ecdsa';
+
+  /**
+   * Create a new HCS-2 client
+   * @param config Client configuration
+   */
+  constructor(config: SDKHCS2ClientConfig) {
+    super({
+      network: config.network,
+      logLevel: config.logLevel,
+      silent: config.silent,
+      mirrorNodeUrl: config.mirrorNodeUrl,
+    });
+
+    // Store operator information
+    this.operatorId = typeof config.operatorId === 'string' 
+      ? AccountId.fromString(config.operatorId) 
+      : config.operatorId;
+
+    // Handle key type detection
+    if (config.keyType) {
+      this.keyType = config.keyType;
+      this.operatorKey = typeof config.operatorKey === 'string'
+        ? this.keyType === 'ecdsa'
+          ? PrivateKey.fromStringECDSA(config.operatorKey)
+          : PrivateKey.fromStringED25519(config.operatorKey)
+        : config.operatorKey;
+    } else if (typeof config.operatorKey === 'string') {
+      try {
+        const keyDetection = detectKeyTypeFromString(config.operatorKey);
+        this.operatorKey = keyDetection.privateKey;
+        this.keyType = keyDetection.detectedType;
+      } catch (error) {
+        this.logger.warn(
+          'Failed to detect key type from private key format, defaulting to ED25519',
+        );
+        this.keyType = 'ed25519';
+        this.operatorKey = PrivateKey.fromString(config.operatorKey);
+      }
+    } else {
+      this.operatorKey = config.operatorKey;
+      this.keyType = 'ed25519'; // Default if we can't detect
+    }
+
+    // Create Hedera client
+    this.client = this.createClient(config.network);
+    
+    // Initialize the client
+    this.initializeClient();
+  }
+
+  /**
+   * Initialize the Hedera client with operator information
+   */
+  private initializeClient(): void {
+    try {
+      this.client.setOperator(this.operatorId, this.operatorKey);
+      this.initialized = true;
+      this.logger.info(`HCS-2 client initialized successfully with key type: ${this.keyType}`);
+    } catch (error) {
+      this.logger.error(`Failed to initialize HCS-2 client: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Create a Hedera client for the specified network
+   * @param network The network to connect to
+   * @returns The Hedera client
+   */
+  private createClient(network: NetworkType): Client {
+    if (network === 'mainnet') {
+      return Client.forMainnet();
+    } else {
+      return Client.forTestnet();
+    }
+  }
+
+  /**
+   * Create a new registry topic
+   * @param options Registry creation options
+   * @returns Promise resolving to the transaction result
+   */
+  async createRegistry(options: CreateRegistryOptions = {}): Promise<TopicRegistrationResponse> {
+    try {
+      const registryType = options.registryType ?? HCS2RegistryType.INDEXED;
+      const ttl = options.ttl ?? 86400; // Default TTL: 24 hours
+      
+      const memo = options.memo 
+        ? `${this.generateRegistryMemo(registryType, ttl)} ${options.memo}`.trim() 
+        : this.generateRegistryMemo(registryType, ttl);
+      
+      let transaction = new TopicCreateTransaction()
+        .setTopicMemo(memo);
+      
+      // Add admin key if requested
+      let adminKeyPrivate: PrivateKey | undefined;
+      if (options.adminKey) {
+        let adminPublicKey: PublicKey;
+        if (typeof options.adminKey === 'string') {
+          adminPublicKey = PublicKey.fromString(options.adminKey);
+        } else if (typeof options.adminKey === 'boolean') {
+          adminPublicKey = this.operatorKey.publicKey;
+        } else {
+          // Provided as PrivateKey instance
+          adminPublicKey = options.adminKey.publicKey;
+          adminKeyPrivate = options.adminKey;
+        }
+        transaction = transaction.setAdminKey(adminPublicKey);
+      }
+      
+      // Add submit key if requested
+      let submitKeyPrivate: PrivateKey | undefined;
+      if (options.submitKey) {
+        let submitPublicKey: PublicKey;
+        if (typeof options.submitKey === 'string') {
+          submitPublicKey = PublicKey.fromString(options.submitKey);
+        } else if (typeof options.submitKey === 'boolean') {
+          submitPublicKey = this.operatorKey.publicKey;
+        } else {
+          submitPublicKey = options.submitKey.publicKey;
+          submitKeyPrivate = options.submitKey;
+        }
+        transaction = transaction.setSubmitKey(submitPublicKey);
+      }
+      
+
+      const frozenTx = await transaction.freezeWith(this.client);
+
+
+      if (adminKeyPrivate) {
+        await frozenTx.sign(adminKeyPrivate);
+      }
+
+      if (submitKeyPrivate) {
+        await frozenTx.sign(submitKeyPrivate);
+      }
+
+      const txResponse = await frozenTx.execute(this.client);
+      
+      const receipt = await txResponse.getReceipt(this.client);
+      const topicId = receipt.topicId;
+      
+      if (!topicId) {
+        throw new Error('Failed to create registry: No topic ID in receipt');
+      }
+      
+      const topicIdStr = topicId.toString();
+      
+      this.logger.info(`Created registry topic: ${topicIdStr} (${registryType === HCS2RegistryType.INDEXED ? 'Indexed' : 'Non-indexed'}, TTL: ${ttl}s)`);
+      
+      return {
+        success: true,
+        topicId: topicIdStr,
+        transactionId: txResponse.transactionId.toString()
+      };
+    } catch (error) {
+      this.logger.error(`Failed to create registry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to create registry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Register a new entry in the registry
+   * @param registryTopicId The topic ID of the registry
+   * @param options Registration options
+   * @returns Promise resolving to the operation result
+   */
+  async registerEntry(registryTopicId: string, options: RegisterEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Create register message
+      const message = this.createRegisterMessage(
+        options.targetTopicId,
+        options.metadata,
+        options.memo
+      );
+
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Registered entry in registry ${registryTopicId} pointing to topic ${options.targetTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to register entry: ${error}`);
+      return {
+        success: false,
+        error: `Failed to register entry: ${error}`
+      };
+    }
+  }
+
+  /**
+   * Update an existing entry in the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Update options
+   * @returns Promise resolving to the operation result
+   */
+  async updateEntry(registryTopicId: string, options: UpdateEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Verify registry type (only indexed registries support updates)
+      const registryInfo = await this.mirrorNode.getTopicInfo(registryTopicId);
+      const memoInfo = this.parseRegistryTypeFromMemo(registryInfo.memo);
+      
+      if (!memoInfo || memoInfo.registryType !== HCS2RegistryType.INDEXED) {
+        throw new Error('Update operation is only valid for indexed registries');
+      }
+      
+      const message = this.createUpdateMessage(
+        options.targetTopicId,
+        options.uid,
+        options.metadata,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Updated entry with UID ${options.uid} in registry ${registryTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to update entry: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Delete an entry from the registry (indexed registries only)
+   * @param registryTopicId The topic ID of the registry
+   * @param options Delete options
+   * @returns Promise resolving to the operation result
+   */
+  async deleteEntry(registryTopicId: string, options: DeleteEntryOptions): Promise<RegistryOperationResponse> {
+    try {
+      // Verify registry type (only indexed registries support deletions)
+      const registryInfo = await this.mirrorNode.getTopicInfo(registryTopicId);
+      const memoInfo = this.parseRegistryTypeFromMemo(registryInfo.memo);
+      
+      if (!memoInfo || memoInfo.registryType !== HCS2RegistryType.INDEXED) {
+        throw new Error('Delete operation is only valid for indexed registries');
+      }
+      
+      const message = this.createDeleteMessage(
+        options.uid,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Deleted entry with UID ${options.uid} from registry ${registryTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to delete entry: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Migrate a registry to a new topic
+   * @param registryTopicId The topic ID of the registry
+   * @param options Migration options
+   * @returns Promise resolving to the operation result
+   */
+  async migrateRegistry(registryTopicId: string, options: MigrateTopicOptions): Promise<RegistryOperationResponse> {
+    try {
+      const message = this.createMigrateMessage(
+        options.targetTopicId,
+        options.metadata,
+        options.memo
+      );
+      
+      const receipt = await this.submitMessage(registryTopicId, message);
+      
+      this.logger.info(`Migrated registry ${registryTopicId} to ${options.targetTopicId}`);
+      
+      return {
+        success: true,
+        receipt,
+        sequenceNumber: receipt.topicSequenceNumber?.low ?? undefined
+      };
+    } catch (error) {
+      this.logger.error(`Failed to migrate registry: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all entries from a registry
+   * @param topicId The topic ID of the registry
+   * @param options Query options
+   * @returns Promise resolving to the registry information
+   */
+  async getRegistry(topicId: string, options: QueryRegistryOptions = {}): Promise<TopicRegistry> {
+    try {
+      const topicInfo = await this.mirrorNode.getTopicInfo(topicId);
+      this.logger.debug(`Retrieved topic info for ${topicId}: ${JSON.stringify(topicInfo)}`);
+      
+      const memoInfo = this.parseRegistryTypeFromMemo(topicInfo.memo);
+      
+      if (!memoInfo) {
+        throw new Error(`Topic ${topicId} is not an HCS-2 registry (invalid memo format)`);
+      }
+      
+      this.logger.debug(`Retrieving messages for topic ${topicId} with limit ${options.limit ?? 100}`);
+      const rawMessagesResult = await this.mirrorNode.getTopicMessages(
+        topicId,
+        {
+          sequenceNumber: options.skip && options.skip > 0 ? `gt:${options.skip}` : undefined,
+          limit: options.limit ?? 100,
+          order: options.order ?? 'asc'
+        }
+      ) as any[];
+      
+      const rawMessages = options.limit ? rawMessagesResult.slice(0, options.limit) : rawMessagesResult;
+      
+      this.logger.debug(`Retrieved ${rawMessagesResult.length} messages, using ${rawMessages.length} after applying limit.`);
+      
+      // Convert messages to the format expected by parseRegistryEntries
+      const entries: RegistryEntry[] = [];
+      let latestEntry: RegistryEntry | undefined;
+      
+      for (const msg of rawMessages) {
+        try {
+          // The mirror node service already parsed the JSON, so we can use it directly
+          const message: HCS2Message = {
+            p: 'hcs-2',
+            op: msg.op,
+            t_id: msg.t_id,
+            uid: msg.uid,
+            metadata: msg.metadata,
+            m: msg.m
+          } as HCS2Message;
+          
+          // Validate message
+          const { valid, errors } = this.validateMessage(message);
+          if (!valid) {
+            this.logger.warn(`Invalid HCS-2 message: ${errors.join(', ')}`);
+            continue;
+          }
+          
+          const entry: RegistryEntry = {
+            topicId,
+            sequence: msg.sequence_number,
+            timestamp: msg.consensus_timestamp,
+            payer: msg.payer_account_id || msg.payer || '',
+            message,
+            consensus_timestamp: msg.consensus_timestamp,
+            registry_type: memoInfo.registryType
+          };
+          
+          entries.push(entry);
+          
+          // For non-indexed registries, we only care about the latest message
+          if (memoInfo.registryType === HCS2RegistryType.NON_INDEXED || !latestEntry || entry.timestamp > latestEntry.timestamp) {
+            latestEntry = entry;
+          }
+        } catch (error) {
+          this.logger.warn(`Error processing message: ${error}`);
+        }
+      }
+      
+      this.logger.debug(`Processed ${entries.length} valid entries for registry ${topicId}`);
+      
+      const registry: TopicRegistry = {
+        topicId,
+        registryType: memoInfo.registryType,
+        ttl: memoInfo.ttl,
+        entries: memoInfo.registryType === HCS2RegistryType.INDEXED ? entries : (latestEntry ? [latestEntry] : []),
+        latestEntry
+      };
+      
+      return registry;
+    } catch (error) {
+      this.logger.error(`Failed to get registry: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Submit a message to a topic
+   * @param topicId The topic ID to submit to
+   * @param payload The message payload
+   * @returns Promise resolving to the transaction receipt
+   */
+  async submitMessage(topicId: string, payload: HCS2Message): Promise<TransactionReceipt> {
+    try {
+      // Validate message
+      const { valid, errors } = this.validateMessage(payload);
+      if (!valid) {
+        throw new Error(`Invalid HCS-2 message: ${errors.join(', ')}`);
+      }
+      
+      const transaction = new TopicMessageSubmitTransaction()
+        .setTopicId(TopicId.fromString(topicId))
+        .setMessage(JSON.stringify(payload));
+      
+      const txResponse = await transaction.execute(this.client);
+      
+      const receipt = await txResponse.getReceipt(this.client);
+      
+      return receipt;
+    } catch (error) {
+      this.logger.error(`Failed to submit message: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * @param topicId The topic ID to query
+   * @returns Promise resolving to the topic information
+   */
+  public async getTopicInfo(topicId: string): Promise<any> {
+    return this.mirrorNode.getTopicInfo(topicId);
+  }
+
+  /**
+   * Close the client and release resources
+   */
+  public close(): void {
+    this.client.close();
+    this.logger.info('HCS-2 client closed.');
+  }
+
+  /**
+   * Get the configured key type (ed25519 or ecdsa)
+   */
+  public getKeyType(): 'ed25519' | 'ecdsa' {
+    return this.keyType;
+  }
+
+  /**
+   * Get the configured operator private key
+   */
+  public getOperatorKey(): PrivateKey {
+    return this.operatorKey;
+  }
+} 

--- a/src/hcs-2/types.ts
+++ b/src/hcs-2/types.ts
@@ -1,0 +1,244 @@
+import { LogLevel } from '../utils/logger';
+import { NetworkType } from '../utils/types';
+import { HederaMirrorNode } from '../services/mirror-node';
+import { TransactionReceipt, PrivateKey } from '@hashgraph/sdk';
+import { z } from 'zod';
+
+/**
+ * HCS-2 operation types
+ * - register: Add a new entry/version
+ * - update: Modify a previous entry (indexed topics only)
+ * - delete: Remove an entry by uid (indexed topics only)
+ * - migrate: Move a topic to a new one
+ */
+export enum HCS2Operation {
+  REGISTER = 'register',
+  UPDATE = 'update',
+  DELETE = 'delete',
+  MIGRATE = 'migrate'
+}
+
+/**
+ * HCS-2 registry type
+ * - 0: Indexed registry - All records are considered for processing
+ * - 1: Non-indexed registry - Only the latest message is considered
+ */
+export enum HCS2RegistryType {
+  INDEXED = 0,
+  NON_INDEXED = 1
+}
+
+/**
+ * Base HCS-2 message format
+ */
+export interface HCS2Message {
+  p: string; // Protocol (always "hcs-2")
+  op: HCS2Operation; // Operation
+  t_id?: string; // Target Topic ID (for register, update, migrate)
+  uid?: string; // Unique ID/Sequence number (for update, delete)
+  metadata?: string; // Metadata URI (HIP-412 format)
+  m?: string; // Memo (max 500 chars)
+  ttl?: number; // Time to live (in seconds, optional override)
+}
+
+/**
+ * Register operation message
+ */
+export interface HCS2RegisterMessage extends HCS2Message {
+  op: HCS2Operation.REGISTER;
+  t_id: string;
+}
+
+/**
+ * Update operation message
+ */
+export interface HCS2UpdateMessage extends HCS2Message {
+  op: HCS2Operation.UPDATE;
+  uid: string;
+  t_id: string;
+}
+
+/**
+ * Delete operation message
+ */
+export interface HCS2DeleteMessage extends HCS2Message {
+  op: HCS2Operation.DELETE;
+  uid: string;
+}
+
+/**
+ * Migrate operation message
+ */
+export interface HCS2MigrateMessage extends HCS2Message {
+  op: HCS2Operation.MIGRATE;
+  t_id: string;
+}
+
+/**
+ * Configuration for HCS-2 client
+ */
+export interface HCS2ClientConfig {
+  network: NetworkType;
+  logLevel?: LogLevel;
+  silent?: boolean;
+  mirrorNodeUrl?: string;
+}
+
+/**
+ * Response from topic registration
+ */
+export interface TopicRegistrationResponse {
+  success: boolean;
+  topicId?: string;
+  transactionId?: string;
+  error?: string;
+}
+
+/**
+ * Response from a registry operation
+ */
+export interface RegistryOperationResponse {
+  success: boolean;
+  transactionId?: string;
+  receipt?: TransactionReceipt;
+  error?: string;
+  sequenceNumber?: number;
+}
+
+/**
+ * Registry entry information
+ */
+export interface RegistryEntry {
+  topicId: string;
+  sequence: number;
+  timestamp: string;
+  payer: string;
+  message: HCS2Message;
+  consensus_timestamp: string;
+  registry_type: HCS2RegistryType;
+}
+
+/**
+ * Topic registry information
+ */
+export interface TopicRegistry {
+  topicId: string;
+  registryType: HCS2RegistryType;
+  ttl: number;
+  entries: RegistryEntry[];
+  latestEntry?: RegistryEntry;
+}
+
+/**
+ * Options for creating a new registry
+ */
+export interface CreateRegistryOptions {
+  memo?: string;
+  ttl?: number;
+  adminKey?: boolean | string | PrivateKey;
+  submitKey?: boolean | string | PrivateKey;
+  registryType?: HCS2RegistryType;
+}
+
+/**
+ * Options for registering a topic entry
+ */
+export interface RegisterEntryOptions {
+  targetTopicId: string;
+  metadata?: string;
+  memo?: string;
+}
+
+/**
+ * Options for updating a topic entry
+ */
+export interface UpdateEntryOptions {
+  targetTopicId: string;
+  uid: string;
+  metadata?: string;
+  memo?: string;
+}
+
+/**
+ * Options for deleting a topic entry
+ */
+export interface DeleteEntryOptions {
+  uid: string;
+  memo?: string;
+}
+
+/**
+ * Options for migrating a topic
+ */
+export interface MigrateTopicOptions {
+  targetTopicId: string;
+  metadata?: string;
+  memo?: string;
+}
+
+/**
+ * Options for querying registry entries
+ */
+export interface QueryRegistryOptions {
+  limit?: number;
+  order?: 'asc' | 'desc';
+  skip?: number;
+}
+
+/**
+ * Zod schemas for HCS-2 message validation
+ */
+
+// Topic ID validation (e.g., "0.0.123456")
+export const topicIdSchema = z.string().regex(/^\d+\.\d+\.\d+$/, {
+  message: "Topic ID must be in Hedera format (e.g., '0.0.123456')"
+});
+
+// Base HCS-2 message schema
+export const baseMessageSchema = z.object({
+  p: z.literal('hcs-2'),
+  op: z.enum([
+    HCS2Operation.REGISTER, 
+    HCS2Operation.UPDATE, 
+    HCS2Operation.DELETE, 
+    HCS2Operation.MIGRATE
+  ]),
+  m: z.string().max(500, "Memo must not exceed 500 characters").optional(),
+  ttl: z.number().int().positive().optional()
+});
+
+// Register message schema
+export const registerMessageSchema = baseMessageSchema.extend({
+  op: z.literal(HCS2Operation.REGISTER),
+  t_id: topicIdSchema,
+  metadata: z.string().optional()
+});
+
+// Update message schema
+export const updateMessageSchema = baseMessageSchema.extend({
+  op: z.literal(HCS2Operation.UPDATE),
+  uid: z.string(),
+  t_id: topicIdSchema,
+  metadata: z.string().optional()
+});
+
+// Delete message schema
+export const deleteMessageSchema = baseMessageSchema.extend({
+  op: z.literal(HCS2Operation.DELETE),
+  uid: z.string()
+});
+
+// Migrate message schema
+export const migrateMessageSchema = baseMessageSchema.extend({
+  op: z.literal(HCS2Operation.MIGRATE),
+  t_id: topicIdSchema,
+  metadata: z.string().optional()
+});
+
+// Combined schema for all message types
+export const hcs2MessageSchema = z.discriminatedUnion("op", [
+  registerMessageSchema,
+  updateMessageSchema,
+  deleteMessageSchema,
+  migrateMessageSchema
+]); 

--- a/src/utils/is-browser.ts
+++ b/src/utils/is-browser.ts
@@ -1,0 +1,4 @@
+/**
+ * Determines if the current environment is a browser
+ */
+export const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined'; 


### PR DESCRIPTION

This PR replaces [#35](https://github.com/hashgraph-online/hashgraph-online-standards-sdk-js/pull/35), which had DCO and branch history issues.  
All previous changes and feedback have been incorporated, and the branch is now properly based on the latest `main` with DCO signoffs on all commits.

---

**Summary of changes:**
  - HCS-2 integration tests for custom key management and key type detection
  - Enhanced key management and transaction handling
  - Improved error handling and schema validation

---

**Note:**  
Please review and approve this PR in place of #35. Thank you!

---
