### PR TITLE
refactor(hcs-2): simplify memo generation in registry options

### DIFF
--- a/src/hcs-2/browser.ts
+++ b/src/hcs-2/browser.ts
@@ -82,9 +82,7 @@ export class BrowserHCS2Client extends HCS2BaseClient {
       const registryType = options.registryType ?? HCS2RegistryType.INDEXED;
       const ttl = options.ttl ?? 86400; // Default TTL: 24 hours
       
-      const memo = options.memo 
-        ? `${this.generateRegistryMemo(registryType, ttl)} ${options.memo}`.trim() 
-        : this.generateRegistryMemo(registryType, ttl);
+      const memo = this.generateRegistryMemo(registryType, ttl);
       
       let transaction = new TopicCreateTransaction()
         .setTopicMemo(memo);

--- a/src/hcs-2/client.ts
+++ b/src/hcs-2/client.ts
@@ -132,9 +132,7 @@ export class HCS2Client extends HCS2BaseClient {
       const registryType = options.registryType ?? HCS2RegistryType.INDEXED;
       const ttl = options.ttl ?? 86400; // Default TTL: 24 hours
       
-      const memo = options.memo 
-        ? `${this.generateRegistryMemo(registryType, ttl)} ${options.memo}`.trim() 
-        : this.generateRegistryMemo(registryType, ttl);
+      const memo = this.generateRegistryMemo(registryType, ttl);
       
       let transaction = new TopicCreateTransaction()
         .setTopicMemo(memo);

--- a/src/hcs-2/types.ts
+++ b/src/hcs-2/types.ts
@@ -133,11 +133,10 @@ export interface TopicRegistry {
  * Options for creating a new registry
  */
 export interface CreateRegistryOptions {
-  memo?: string;
-  ttl?: number;
-  adminKey?: boolean | string | PrivateKey;
-  submitKey?: boolean | string | PrivateKey;
   registryType?: HCS2RegistryType;
+  ttl?: number;
+  adminKey?: string | boolean | PrivateKey;
+  submitKey?: string | boolean | PrivateKey;
 }
 
 /**


### PR DESCRIPTION
Refactors the memo generation logic in the BrowserHCS2Client and HCS2Client classes to remove the conditional concatenation with options.memo. The memo is now consistently generated using only the registry type and TTL, enhancing code clarity and maintainability.

Additionally, updates the CreateRegistryOptions interface to streamline the memo and key properties.